### PR TITLE
Add Codex setup script and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Codex Setup
+
+This repository integrates [OpenAI Codex](https://github.com/openai/codex) using a helper script.
+
+## Installing Codex
+
+Run the setup script to clone the Codex repository and install its dependencies. By default
+Codex is cloned to `vendor/codex`.
+
+```bash
+scripts/setup_codex.sh
+```
+
+The script will attempt to install dependencies using `npm` or `pip` depending on the files
+present in the Codex repository. If Codex has different requirements, adjust the script
+accordingly.
+
+## Configuration
+
+Codex can be configured with `codex.yaml`. The default configuration enables the OpenAI style:
+
+```yaml
+style: openai
+```
+
+Adjust this file to suit your workflow.
+
+## Using Codex
+
+After running the setup script, consult the Codex repository's documentation for available
+commands. Typically you might run a CLI inside the cloned `vendor/codex` directory.
+
+```
+cd vendor/codex
+# Example usage (replace with actual command)
+./codex --help
+```
+

--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,1 @@
+style: openai

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CODEX_DIR=${CODEX_DIR:-"vendor/codex"}
+
+if [ -d "$CODEX_DIR/.git" ]; then
+  echo "Codex already cloned to $CODEX_DIR"
+else
+  git clone https://github.com/openai/codex "$CODEX_DIR"
+fi
+cd "$CODEX_DIR"
+if [ -f package.json ]; then
+  npm install
+elif [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+else
+  echo "No package.json or requirements.txt found. Please install dependencies manually." >&2
+fi


### PR DESCRIPTION
## Summary
- integrate Codex setup instructions in README
- add helper script to clone and install Codex
- provide default codex.yaml configuration

## Testing
- `git status --short`
