### PR TITLE
Organize tasks into per-folder documentation

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -1,7 +1,6 @@
 # Task List
 
-Keep this list up to date with open development tasks.
+Tasks are organized in the `tasks/` directory.
 
-- [ ] Improve test coverage for `apps/server`
-- [ ] Document deployment steps for the Bot-or-Not game
-
+- [ ] [Improve server unit test coverage](../tasks/improve-server-test-coverage/task-improve-server-test-coverage.md)
+- [ ] [Document Bot-or-Not deployment steps](../tasks/document-bot-or-not-deployment/task-document-bot-or-not-deployment.md)

--- a/tasks/document-bot-or-not-deployment/task-document-bot-or-not-deployment.md
+++ b/tasks/document-bot-or-not-deployment/task-document-bot-or-not-deployment.md
@@ -1,0 +1,3 @@
+# Document Bot-or-Not deployment steps
+
+Create clear instructions for deploying the Bot-or-Not game, including environment setup, build commands, and hosting details.

--- a/tasks/improve-server-test-coverage/task-improve-server-test-coverage.md
+++ b/tasks/improve-server-test-coverage/task-improve-server-test-coverage.md
@@ -1,0 +1,3 @@
+# Improve server unit test coverage
+
+Add or update unit tests in `apps/server` to increase overall coverage. Ensure `bun test --coverage` passes and that new tests are written in TypeScript.


### PR DESCRIPTION
## Summary
- create dedicated `tasks/` directory for individual task docs
- move items from `.vibe/tasks.md` into their own markdown files
- update `.vibe/tasks.md` to link to new task locations

## Testing
- `bun test --coverage`
