### PR TITLE
Use import.meta.url for task-cli entry

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -4,4 +4,5 @@ Keep this list up to date with open development tasks.
 
 - [ ] Improve test coverage for `apps/server`
 - [ ] Document deployment steps for the Bot-or-Not game
+- [x] Update CLI invocation detection to use import.meta.url
 

--- a/libs/task-cli/src/index.ts
+++ b/libs/task-cli/src/index.ts
@@ -1,3 +1,5 @@
+import {pathToFileURL} from 'url';
+
 export interface NewsArticle {
   title: string;
   link: string;
@@ -62,7 +64,8 @@ export async function cli(args: string[] = process.argv.slice(2)) {
   await run(args);
 }
 
-if (require.main === module) {
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
   cli().catch((err) => {
     console.error(err);
     process.exit(1);

--- a/tasks/cli-import-meta-detection/task-cli-import-meta-detection.md
+++ b/tasks/cli-import-meta-detection/task-cli-import-meta-detection.md
@@ -1,0 +1,6 @@
+# Update CLI invocation detection
+
+* Replace `require.main` logic in `libs/task-cli` with an `import.meta.url` check.
+* Ensure the CLI still functions when run via `bun run`.
+* Remove CommonJS-specific `module` checks.
+* Verify via `bun test` and manual execution.


### PR DESCRIPTION
## Summary
- add docs for updating CLI invocation detection
- note completed task in task list
- use `import.meta.url` check in `task-cli`

## Testing
- `bun test --coverage`
- `bun run libs/task-cli/src/index.ts file:///tmp/feed.xml`
- `npx tsc --noEmit -p tsconfig.base.json` *(fails: Cannot find module 'react', etc.)*