### PR TITLE
Use import.meta.url for dirname

### DIFF
--- a/apps/server/src/bot.ts
+++ b/apps/server/src/bot.ts
@@ -1,5 +1,8 @@
 import fs from 'fs';
 import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import {Server} from 'socket.io';
 import {Ollama} from 'ollama';
 import {Player} from './types';

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,9 +3,12 @@ import http from 'http';
 import {Server} from 'socket.io';
 import fs from 'fs';
 import path from 'path';
+import {fileURLToPath} from 'url';
 import {maskMessage} from './mask';
 import {initBot} from './bot';
 import {Player} from './types';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const app = express();
 const server = http.createServer(app);

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,6 @@
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 console.log("Hello via Bun!");

--- a/tasks/replace-dirname-import-meta-url/task-replace-dirname-import-meta-url.md
+++ b/tasks/replace-dirname-import-meta-url/task-replace-dirname-import-meta-url.md
@@ -1,0 +1,3 @@
+# Replace __dirname with import.meta.url
+
+This task updates server files to derive `__dirname` using `fileURLToPath(import.meta.url)`. Both `apps/server/src/bot.ts` and `apps/server/src/index.ts` now compute their own `__dirname` variable so paths resolve correctly in ESM environments.


### PR DESCRIPTION
## Summary
- compute `__dirname` using `fileURLToPath(import.meta.url)` in server bot and index
- update root index.ts similarly
- document the task

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*
- `bun test --coverage`