### PR TITLE
Update tasks for type packages completion

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -6,4 +6,5 @@ corresponding folder under `./tasks` with additional documentation.
 - [ ] Improve test coverage for `apps/server`
 - [ ] Document deployment steps for the Bot-or-Not game
 - [ ] Evaluate need for an `example-agent` in the future
+- [x] Add TypeScript type packages
 

--- a/tasks/add-types-dev-deps/task-add-types-dev-deps.md
+++ b/tasks/add-types-dev-deps/task-add-types-dev-deps.md
@@ -1,3 +1,7 @@
 # Add TypeScript type packages
 
 Add development dependencies for common type packages including `@types/node`, `@types/express`, `@types/react`, and `@types/react-dom`. Update the client application tsconfig to include DOM libraries so the React app compiles correctly.
+
+## Notes
+
+These dependencies were added to `package.json` under `devDependencies`. The React application's `tsconfig.app.json` now specifies `lib: ["DOM", "ESNext"]` so the compiler includes DOM types.


### PR DESCRIPTION
## Summary
- mark the add-types-dev-deps work as completed in `.vibe/tasks.md`
- document dev dependencies and DOM libs in `task-add-types-dev-deps.md`

## Testing
- `bun test --coverage`