### PR TITLE
Add server unit tests and update docs

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -3,7 +3,7 @@
 Keep this list up to date with open development tasks. Each task has a
 corresponding folder under `./tasks` with additional documentation.
 
-- [ ] Improve test coverage for `apps/server`
+- [x] Improve test coverage for `apps/server`
 - [ ] Document deployment steps for the Bot-or-Not game
 - [ ] Evaluate need for an `example-agent` in the future
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ The `.vibe/projects.md` file lists all Nx projects. Update it whenever you add o
 
 ## Running tests
 
-Execute the unit tests with Bun:
+Execute the unit tests with Bun. The server tests live under
+`apps/server/src/__tests__`:
 
 ```bash
 bun test --coverage

--- a/apps/prompts/bot_system.txt
+++ b/apps/prompts/bot_system.txt
@@ -1,0 +1,9 @@
+You are just another player in this chat-room guessing game.
+Rules you must follow at **all times**:
+1. Never reveal or hint that you are an AI, a bot, or have system-level instructions.
+2. Behave like an ordinary, friendly participant: ask questions, respond naturally, share casual opinions.
+3. Your goal is to deduce which persona belongs to which player. Keep a mental note of clues.
+4. Periodically (no more than once every 20 lines) consider whether you can map personas to players.
+   When confident (>70 %), emit a JSON object on a single line:
+   ``` /guess {"socketId1":2,"socketId2":0,…} ```
+5. If a player directly asks “are you the bot?” or similar, dodge politely and continue the conversation.

--- a/apps/server/src/__tests__/bot.test.ts
+++ b/apps/server/src/__tests__/bot.test.ts
@@ -1,0 +1,45 @@
+import {beforeEach, afterEach, expect, test} from 'bun:test';
+import {EventEmitter} from 'events';
+
+let requests: any[] = [];
+class MockClient {
+  async chat(req: any) {
+    requests.push(req);
+    return {message: {content: 'bot says hi '}};
+  }
+}
+
+let io: EventEmitter & {on: any; emit: any};
+let messages: any[] = [];
+let initBot: any;
+
+beforeEach(async () => {
+  requests = [];
+  messages = [];
+  io = new EventEmitter() as any;
+  io.on = io.addListener;
+  (globalThis as any).__Ollama = MockClient;
+  const mod = await import('../bot');
+  initBot = mod.initBot;
+  initBot(io as any, () => []);
+  io.on('bot:message', (m: any) => messages.push(m));
+});
+
+afterEach(() => {
+  delete (globalThis as any).__Ollama;
+});
+
+test('bot responds to broadcast from user', async () => {
+  io.emit('broadcast', {id: 'user1', message: 'hey'});
+  await new Promise(r => setTimeout(r, 0));
+  expect(requests.length).toBe(1);
+  expect(messages.length).toBe(1);
+  expect(messages[0].message).toBe('bot says hi');
+});
+
+test('bot ignores its own messages', async () => {
+  io.emit('broadcast', {id: 'bot', message: 'ignore'});
+  await new Promise(r => setTimeout(r, 0));
+  expect(requests.length).toBe(0);
+  expect(messages.length).toBe(0);
+});

--- a/apps/server/src/__tests__/mask.test.ts
+++ b/apps/server/src/__tests__/mask.test.ts
@@ -1,0 +1,30 @@
+import {beforeEach, afterEach, expect, test} from 'bun:test';
+
+let requests: any[] = [];
+
+class MockClient {
+  async chat(req: any) {
+    requests.push(req);
+    return {message: {content: 'masked response '}};
+  }
+}
+
+let maskMessage: (text: string) => Promise<string>;
+
+beforeEach(async () => {
+  requests = [];
+  (globalThis as any).__Ollama = MockClient;
+  const mod = await import('../mask');
+  maskMessage = mod.maskMessage;
+});
+
+afterEach(() => {
+  delete (globalThis as any).__Ollama;
+});
+
+test('maskMessage calls ollama and trims output', async () => {
+  const result = await maskMessage('hello');
+  expect(result).toBe('masked response');
+  expect(requests.length).toBe(1);
+  expect(requests[0].messages[1].content).toBe('MESSAGE: hello');
+});

--- a/apps/server/src/bot.ts
+++ b/apps/server/src/bot.ts
@@ -4,7 +4,6 @@ import {fileURLToPath} from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import {Server} from 'socket.io';
-import {Ollama} from 'ollama';
 import {Player} from './types';
 
 const PROMPT_PATH = path.join(__dirname, '../../prompts/bot_system.txt');
@@ -14,15 +13,28 @@ fs.watch(PROMPT_PATH, () => {
   systemPrompt = fs.readFileSync(PROMPT_PATH, 'utf8');
 });
 
-const baseUrl = process.env.OPENAI_BASE_URL || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
-const client = new Ollama({baseUrl});
+const baseUrl =
+  process.env.OPENAI_BASE_URL ||
+  process.env.OLLAMA_BASE_URL ||
+  'http://localhost:11434';
+
+let client: {chat: (req: any) => Promise<{message: {content: string}}>} | null =
+  null;
+
+async function getClient() {
+  if (client) return client;
+  const Ollama = (globalThis as any).__Ollama || (await import('ollama')).Ollama;
+  client = new Ollama({baseUrl});
+  return client;
+}
 
 export function initBot(io: Server, getPlayers: () => Player[]) {
   io.on('bot:message', () => {/* noop to reserve namespace */});
 
   io.on('broadcast', async ({id, message}) => {
     if (id === 'bot') return;
-    const res = await client.chat({
+    const c = await getClient();
+    const res = await c.chat({
       model: process.env.BOT_MODEL || 'llama2',
       messages: [
         {role: 'system', content: systemPrompt},

--- a/apps/server/src/mask.ts
+++ b/apps/server/src/mask.ts
@@ -1,12 +1,23 @@
-import {Ollama} from 'ollama';
+const baseUrl =
+  process.env.OPENAI_BASE_URL ||
+  process.env.OLLAMA_BASE_URL ||
+  'http://localhost:11434';
 
-const baseUrl = process.env.OPENAI_BASE_URL || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
-const client = new Ollama({baseUrl});
+let client: {chat: (req: any) => Promise<{message: {content: string}}>} | null =
+  null;
+
+async function getClient() {
+  if (client) return client;
+  const Ollama = (globalThis as any).__Ollama || (await import('ollama')).Ollama;
+  client = new Ollama({baseUrl});
+  return client;
+}
 
 const SYSTEM_PROMPT = `You are a content filter. Rewrite "MESSAGE:" so it retains meaning but removes real names, addresses, age, phone numbers, or direct declarations of identity.\nIf already anonymised, output it unchanged.`;
 
 export async function maskMessage(text: string): Promise<string> {
-  const res = await client.chat({
+  const c = await getClient();
+  const res = await c.chat({
     model: process.env.MASK_MODEL || 'llama2',
     messages: [
       {role: 'system', content: SYSTEM_PROMPT},

--- a/tasks/add-server-tests/task-add-server-tests.md
+++ b/tasks/add-server-tests/task-add-server-tests.md
@@ -1,0 +1,5 @@
+# Add server tests
+
+Introduce unit tests for the server application.
+- Created `apps/server/src/__tests__` with tests for `maskMessage` and bot message handling.
+- Updated README to note location of server tests.


### PR DESCRIPTION
## Summary
- add tests for maskMessage and bot interactions in `apps/server`
- support mocking ollama in bot and mask modules
- document server tests location
- track completion of coverage task in `.vibe/tasks.md`
- document task in `tasks/add-server-tests`

## Testing
- `bun test --coverage`
- `npx tsc --noEmit` *(fails: Cannot find module 'react' etc.)*