### PR TITLE
Update project catalog docs

### DIFF
--- a/.vibe/README.md
+++ b/.vibe/README.md
@@ -3,5 +3,5 @@ agents during development. Files here are optional and may be ignored
 by users not working with the agent tooling.
 
 Open tasks are tracked in `.vibe/tasks.md` with additional details stored
-under the `./tasks` folder.
-
+under the `./tasks` folder. A catalog of projects and outstanding ideas
+is maintained in `.vibe/projects.md`.

--- a/.vibe/projects.md
+++ b/.vibe/projects.md
@@ -2,7 +2,13 @@
 
 This file lists the major Nx projects in the repository. Update it whenever a project is added or removed.
 
-- **client** – React front-end for the Bot-or-Not game (`apps/client`)
+## Applications
 - **server** – Node server for the game (`apps/server`)
+- **client** – React front-end for the Bot-or-Not game (`apps/client`)
+
+## Libraries
 - **task-cli** – Library providing a small RSS-based news gatherer (`libs/task-cli`)
 
+## Outstanding Tasks and Ideas
+- Document deployment steps for the Bot-or-Not game
+- Evaluate need for an example agent in the future

--- a/tasks/evaluate-example-agent/task-evaluate-example-agent.md
+++ b/tasks/evaluate-example-agent/task-evaluate-example-agent.md
@@ -1,0 +1,9 @@
+# Evaluate Example Agent
+
+Explore whether an example agent should be added to demonstrate Vibe CLI usage and agent behaviors.
+
+## Considerations
+- Determine the scope and features of a potential example agent.
+- Decide if the repository should include a minimal starter agent or just documentation.
+- Assess maintenance costs and usefulness to new developers.
+


### PR DESCRIPTION
## Summary
- expand `.vibe/projects.md` with apps, libraries and open ideas
- point `.vibe/README.md` to the project catalog
- track example-agent evaluation task

## Testing
- `bun test --coverage`