### PR TITLE
Add server test instructions

### DIFF
--- a/.vibe/tasks/add-server-tests/user-instructions.md
+++ b/.vibe/tasks/add-server-tests/user-instructions.md
@@ -1,0 +1,16 @@
+# Running server tests
+
+Follow these steps from the repository root to install dependencies, type check the server and run the tests.
+
+1. Install dependencies with `bun install` (or `pnpm install`).
+2. Type check the server project:
+
+```bash
+bun x tsc --noEmit -p apps/server/tsconfig.app.json
+```
+
+3. Execute the tests:
+
+```bash
+bun test
+```


### PR DESCRIPTION
## Summary
- document how to run server dependencies and tests for `add-server-tests`

## Testing
- `bun x tsc --noEmit` *(fails: Cannot find module 'react')*
- `bun test --coverage`