### PR TITLE
Add evaluation task for example agent

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -7,7 +7,7 @@ corresponding folder under `.vibe/tasks` with additional documentation.
 - [x] Install server deps and tests
 - [x] Add main routes and socket tests
 - [ ] Document deployment steps for the Bot-or-Not game
-- [ ] Evaluate need for an `example-agent` in the future
+- [ ] Evaluate need for an `example-agent` in the future [(task)](tasks/evaluate-example-agent/task-evaluate-example-agent.md)
 - [x] Add TypeScript type packages
 - [x] Update README with agentic tools description
 - [x] Create example agent

--- a/.vibe/tasks/evaluate-example-agent/task-evaluate-example-agent.md
+++ b/.vibe/tasks/evaluate-example-agent/task-evaluate-example-agent.md
@@ -1,0 +1,9 @@
+# Evaluate Example Agent
+
+The `example-agent` entry was removed from `mcp.json` in [commit 8f30a5d](../../../../commit/8f30a5d34f28d5e0e17473d6d2ab0e0a880d2fb9) because no implementation existed. This avoided referencing a project that didn't actually run.
+
+A minimal agent was later created in [commit 9fd12ba](../../../../commit/9fd12ba1bc76298c2062ce0d3a5071f44acc431e) to serve as a simple demo. If we remove it again, reintroducing an example agent should meet these criteria:
+
+* Provide at least one runnable entry point with unit tests.
+* Document how the agent integrates with the rest of the repo.
+* Ensure the agent is listed in `mcp.json` only when it has a working implementation.


### PR DESCRIPTION
## Summary
- document rationale for removing example agent and when to bring it back
- link the evaluation task from `.vibe/tasks.md`

## Testing
- `bun test --coverage`
