### PR TITLE
Add queue docs and fix TypeScript build

### DIFF
--- a/.vibe/queue/README.md
+++ b/.vibe/queue/README.md
@@ -1,0 +1,13 @@
+# Queue
+
+This folder holds **activities**, the basic work units for this repository.
+
+Each activity is stored in its own Markdown file named using the pattern:
+
+```
+activity-<timestamp>-<slug>.md
+```
+
+`<timestamp>` is the UTC time in `YYYYMMDDHHMMSS` format. `<slug>` is a short
+hyphenated description of twenty characters or fewer. Activities are the only
+item type currently supported in the queue.

--- a/.vibe/queue/activity-20250530212016-genic-demo-plan.md
+++ b/.vibe/queue/activity-20250530212016-genic-demo-plan.md
@@ -1,0 +1,21 @@
+# Research and demo plan for Genic framework
+
+This activity tracks the work required to research and demonstrate the "genic" framework using common machine learning libraries.
+
+## Libraries
+
+| Library | ≤8-word summary | URL |
+| --- | --- | --- |
+| TensorFlow / Keras | High-level deep learning; autoencoders, GANs, VAEs. | https://www.tensorflow.org/ |
+| PyTorch | Research-friendly neural networks; flexible dynamic graphs. | https://pytorch.org/ |
+| scikit-learn | Classical ML; t-SNE, clustering, metrics. | https://scikit-learn.org/ |
+| Hugging Face Transformers | Pretrained transformer models, embeddings, fine-tuning. | https://huggingface.co/transformers/ |
+
+## Next steps
+
+1. Review each library's documentation.
+2. Identify genic features or equivalents.
+3. Prepare minimal demos using notebooks.
+4. Document the findings.
+
+Status: Active

--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -11,4 +11,5 @@ corresponding folder under `.vibe/tasks` with additional documentation.
 - [x] Add TypeScript type packages
 - [x] Update README with agentic tools description
 - [x] Add fetch error handling
+- [x] [Create queue activity](tasks/create-queue-activity)
 

--- a/.vibe/tasks/create-queue-activity/task-create-queue-activity.md
+++ b/.vibe/tasks/create-queue-activity/task-create-queue-activity.md
@@ -1,0 +1,4 @@
+# Create queue activity
+
+- Added `.vibe/queue` with documentation for activities.
+- Created initial active activity file describing the plan to research and demo the genic framework.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Environment setup & latest features
-    "lib": ["ESNext"],
+    "lib": ["DOM", "ESNext"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- document queue activity naming scheme
- add genic framework demo activity
- fix build by including DOM lib

## Testing
- `bun test --coverage`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683a20ca9ec4832f8cd73e7abf264ff6