### PR TITLE
Add local dev setup docs

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -12,4 +12,5 @@ corresponding folder under `.vibe/tasks` with additional documentation.
 - [x] Update README with agentic tools description
 - [x] Add fetch error handling
 - [x] [Create queue activity](tasks/create-queue-activity)
+- [x] [Document local development setup](tasks/document-local-dev-setup)
 

--- a/.vibe/tasks/document-local-dev-setup/task-document-local-dev-setup.md
+++ b/.vibe/tasks/document-local-dev-setup/task-document-local-dev-setup.md
@@ -1,0 +1,3 @@
+# Document local development setup
+
+Add README instructions for starting Redis and Ollama with `scripts/setup-local-dev.sh` and running the agentic apps using `pnpm agentic:dev`.

--- a/README.md
+++ b/README.md
@@ -127,3 +127,21 @@ Open the client in the browser and follow the prompts to join the chat room.
 
 Utility scripts live under the `scripts/` directory. `setup_codex.sh` clones the
 OpenAI Codex repository and installs its dependencies.
+
+## Local development setup
+
+Start Redis and Ollama using the helper script and the `docker-compose.local.yml`
+file:
+
+```bash
+scripts/setup-local-dev.sh
+```
+
+Create a copy of `.env.example` named `.env` and adjust values like `REDIS_URL`
+and any model names to suit your environment.
+
+With the services running, launch the agentic apps:
+
+```bash
+pnpm agentic:dev
+```


### PR DESCRIPTION
## Summary
- document local development setup in README
- record new docs task

## Testing
- `bun run tsc --noEmit`
- `bun test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_683f8c1524b4832f9218902739e0b31e