### PR TITLE
Document absence of agentic scripts

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -12,4 +12,5 @@ corresponding folder under `.vibe/tasks` with additional documentation.
 - [x] Update README with agentic tools description
 - [x] Add fetch error handling
 - [x] [Create queue activity](tasks/create-queue-activity)
+- [x] [Confirm agentic scripts](tasks/confirm-agentic-scripts)
 

--- a/.vibe/tasks/confirm-agentic-scripts/task-confirm-agentic-scripts.md
+++ b/.vibe/tasks/confirm-agentic-scripts/task-confirm-agentic-scripts.md
@@ -1,0 +1,14 @@
+# Confirm agentic scripts
+
+Investigate Nx project names for the planned chat API and web app and update or remove the `agentic:dev` and `agentic:test` scripts accordingly.
+
+## Findings
+
+- The workspace currently defines the following Nx projects: `client`, `server`, and `task-cli`.
+- There are no projects named `chat-api` or `web-app` yet.
+- `package.json` contains no `agentic:dev` or `agentic:test` scripts.
+- No `scripts/setup-local-dev.sh` file exists.
+
+## Outcome
+
+No code changes were needed. The scripts referenced in the request do not exist, so nothing required updating or removing.


### PR DESCRIPTION
## Summary
- add task documentation confirming that agentic scripts do not exist
- record the task in `.vibe/tasks.md`

## Testing
- `bun run tsc --noEmit`
- `bun test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_683f8bf3586c832f9c08a9b734258731