### PR TITLE
Add agentic setup guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Development Environment
+NODE_ENV=development
+PORT=3000
+API_PORT=8000
+
+# Local Services
+REDIS_URL=redis://localhost:6379
+OLLAMA_URL=http://localhost:11434
+
+# Memory Backend (redis | mistral | postgres)
+MEMORY_BACKEND=redis
+
+# Local Models
+DEFAULT_LOCAL_MODEL=mixtral:8x7b-q4
+FAST_LOCAL_MODEL=mistral:7b-q4
+
+# External Provider Controls
+ENABLE_EXTERNAL_PROVIDERS=false
+DAILY_BUDGET=0.00
+COST_TRACKING_ENABLED=true
+
+# Security
+JWT_SECRET=your-super-secret-jwt-key
+CORS_ORIGIN=http://localhost:3000

--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -12,4 +12,7 @@ corresponding folder under `.vibe/tasks` with additional documentation.
 - [x] Update README with agentic tools description
 - [x] Add fetch error handling
 - [x] [Create queue activity](tasks/create-queue-activity)
+- [x] [Update monorepo for agentic infrastructure](tasks/update-monorepo-for-agentic-infrastructure)
+- [ ] [Fix invalid Nx targets](tasks/fix-invalid-nx-targets)
+- [ ] [Document local agentic development setup](tasks/document-local-agentic-development-setup)
 

--- a/.vibe/tasks/document-local-agentic-development-setup/task-document-local-agentic-development-setup.md
+++ b/.vibe/tasks/document-local-agentic-development-setup/task-document-local-agentic-development-setup.md
@@ -1,0 +1,7 @@
+# Document local agentic development setup
+
+A new Docker Compose file and setup script allow running Redis and Ollama locally for agentic chat development. This task documents how to use these utilities in the README.
+
+- Run `pnpm run local:setup` (or `bash scripts/setup-local-dev.sh`) to install dependencies and start the services.
+- Edit `.env` (copied from `.env.example`) to set `REDIS_URL`, `OLLAMA_URL`, and other variables.
+- Stop the containers with `pnpm run local:stop` when finished.

--- a/.vibe/tasks/fix-invalid-nx-targets/task-fix-invalid-nx-targets.md
+++ b/.vibe/tasks/fix-invalid-nx-targets/task-fix-invalid-nx-targets.md
@@ -1,0 +1,5 @@
+# Fix invalid Nx targets in package.json
+
+The initial agentic infrastructure commit introduced `agentic:dev` and `agentic:test` scripts that referenced Nx projects `agentic-chat-web` and `agentic-chat-api`. These projects do not yet exist in the repo, causing the scripts to fail.
+
+This task removes those scripts until the correct project names are known. The setup script was updated to omit instructions for running them.

--- a/.vibe/tasks/update-monorepo-for-agentic-infrastructure/task-update-monorepo-for-agentic-infrastructure.md
+++ b/.vibe/tasks/update-monorepo-for-agentic-infrastructure/task-update-monorepo-for-agentic-infrastructure.md
@@ -1,0 +1,11 @@
+# Update monorepo for agentic infrastructure
+
+This task introduces the initial infrastructure pieces for the agentic chat work. It adds local service configuration and basic scripts.
+
+## Changes
+- Extended `package.json` with development dependencies and helper scripts.
+- Added `docker-compose.local.yml` for running Redis and Ollama locally.
+- Provided `.env.example` with environment defaults.
+- Added `scripts/setup-local-dev.sh` for easy setup of local services.
+
+These pieces enable starting Redis and Ollama containers, installing dependencies, and preparing the environment for further development.

--- a/README.md
+++ b/README.md
@@ -127,3 +127,19 @@ Open the client in the browser and follow the prompts to join the chat room.
 
 Utility scripts live under the `scripts/` directory. `setup_codex.sh` clones the
 OpenAI Codex repository and installs its dependencies.
+
+### Local agentic development
+
+Use the helper script to start Redis and Ollama with Docker:
+
+```bash
+pnpm run local:setup
+```
+
+The script copies `.env.example` to `.env` if needed. Edit this file to adjust
+variables such as `REDIS_URL`, `OLLAMA_URL`, and model names. Visit
+`http://localhost:8001` for the Redis UI. Stop the containers when finished:
+
+```bash
+pnpm run local:stop
+```

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+services:
+  redis:
+    image: redis/redis-stack:7.2.0-v9
+    container_name: vibe-redis
+    ports:
+      - "6379:6379"
+      - "8001:8001"  # RedisInsight UI
+    volumes:
+      - redis-data:/data
+    environment:
+      - REDIS_ARGS=--save 60 1000 --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  ollama:
+    image: ollama/ollama:0.1.38
+    container_name: vibe-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-models:/root/.ollama
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+      - OLLAMA_KEEP_ALIVE=24h
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  redis-data:
+  ollama-models:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,17 @@
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "nx": "18.0.0"
+    "nx": "18.0.0",
+    "@nx/python": "^18.2.0",
+    "@nx/next": "^18.2.0",
+    "@langchain/langgraph": "^0.0.19",
+    "redis": "^4.6.0",
+    "@redis/search": "^1.1.0",
+    "ai": "^3.2.0",
+    "@ai-sdk/openai": "^0.0.9",
+    "socket.io-client": "^4.7.5",
+    "zustand": "^4.5.2",
+    "msw": "^2.3.0"
   },
   "peerDependencies": {
     "typescript": "^5"
@@ -24,6 +34,9 @@
   "scripts": {
     "nx": "nx",
     "start": "bun run index.ts",
-    "test": "bun test --coverage"
+    "test": "bun test --coverage",
+    "local:setup": "bash scripts/setup-local-dev.sh",
+    "local:start": "docker-compose -f docker-compose.local.yml up -d",
+    "local:stop": "docker-compose -f docker-compose.local.yml down"
   }
 }

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Setting up vibe-cli agentic development environment..."
+
+# Check prerequisites
+command -v docker >/dev/null 2>&1 || { echo "❌ Docker required" >&2; exit 1; }
+command -v pnpm >/dev/null 2>&1 || { echo "❌ PNPM required" >&2; exit 1; }
+
+# Install dependencies
+echo "📦 Installing dependencies..."
+pnpm install
+
+# Start services
+echo "🐳 Starting Redis and Ollama..."
+docker-compose -f docker-compose.local.yml up -d
+
+# Wait for Redis
+echo "⏳ Waiting for Redis..."
+until docker exec vibe-redis redis-cli ping > /dev/null 2>&1; do sleep 1; done
+
+# Wait for Ollama
+echo "⏳ Waiting for Ollama..."
+until docker exec vibe-ollama ollama list > /dev/null 2>&1; do sleep 2; done
+
+# Pull models
+echo "📥 Pulling AI models..."
+docker exec vibe-ollama ollama pull mixtral:8x7b-q4 &
+docker exec vibe-ollama ollama pull mistral:7b-q4 &
+wait
+
+# Setup environment
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo "✏️ Edit .env file for your configuration"
+fi
+
+echo "✅ Setup complete!"
+echo "• Visit http://localhost:8001 for Redis UI"


### PR DESCRIPTION
## Summary
- document local agentic setup in README
- remove invalid Nx scripts
- adjust setup script
- track new infrastructure tasks

## Testing
- `npx tsc --noEmit`
- `bun test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_683f7e50941c832f975606369881af7b