### PR TITLE
Add PR workflow enforcement docs

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -14,4 +14,5 @@ corresponding folder under `.vibe/tasks` with additional documentation.
 - [x] [Create queue activity](tasks/create-queue-activity)
 - [x] [Document local development setup](tasks/document-local-dev-setup)
 - [x] [Setup AI tooling config](tasks/setup-ai-tooling-config)
+- [ ] [Enforce PR process](tasks/enforce-pr-process)
 

--- a/.vibe/tasks/enforce-pr-process/task-enforce-pr-process.md
+++ b/.vibe/tasks/enforce-pr-process/task-enforce-pr-process.md
@@ -1,0 +1,4 @@
+# Enforce PR Process
+
+Add documentation so contributors know the required steps before opening a pull request.
+They must rebase on `main`, run lint and tests, and force push a single commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,15 @@ You can also use `pnpm nx <command>` if you prefer `pnpm`.
 * Update `README.md` and `mcp.json` if configuration or capabilities change.
 * Keep the project catalog `.vibe/projects.md` up to date when adding or removing Nx projects.
 * Ensure the `.vibe/tasks.md` file reflects the current outstanding tasks.
+* Before opening a pull request run:
+
+```bash
+git fetch origin main
+git rebase -i origin/main
+npm run lint
+npm test
+git push --force-with-lease
+```
+
+Your branch must contain a single commit on top of the latest `main` with no merge commits.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,17 @@
 # Contributing
 
 Please open pull requests with clear descriptions and add unit tests for new functionality.
+
+## Pull Request Process
+
+Before opening a PR, ensure your branch is up to date and contains a single commit:
+
+```bash
+git fetch origin main
+git rebase -i origin/main # squash your commits here
+npm run lint
+npm test
+git push --force-with-lease
+```
+
+The PR should have one linear commit on top of `main` with no merge commits.


### PR DESCRIPTION
## Summary
- document PR workflow expectations in the agent guide and contributing guide
- add new task to enforce PR process

## Testing
- `bun x tsc --noEmit`
- `bun test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_683fb7c484ac832fa32c5417cc590301