### PR TITLE
Add reporter agent example

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -15,4 +15,5 @@ corresponding folder under `.vibe/tasks` with additional documentation.
 - [x] [Document local development setup](tasks/document-local-dev-setup)
 - [x] [Setup AI tooling config](tasks/setup-ai-tooling-config)
 - [ ] [Enforce PR process](tasks/enforce-pr-process)
+- [ ] [Document reporter agent invocation](tasks/document-reporter-agent-invocation)
 

--- a/.vibe/tasks/document-reporter-agent-invocation/task-document-reporter-agent-invocation.md
+++ b/.vibe/tasks/document-reporter-agent-invocation/task-document-reporter-agent-invocation.md
@@ -1,0 +1,3 @@
+# Document reporter agent invocation
+
+Add a README example showing how to import `run()` from `agents/generative-ai-reporter-agent` and execute it with sample repository data.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ pnpm --filter @bot-or-not/client dev
 
 Open the client in the browser and follow the prompts to join the chat room.
 
+### Generative AI reporter agent
+
+After installing dependencies you can run the reporter agent directly. Import
+`run()` from `agents/generative-ai-reporter-agent` and provide it with
+repository information:
+
+```ts
+import { run } from "agents/generative-ai-reporter-agent";
+
+run({
+  repoPath: "/path/to/repo",
+  branch: "main",
+});
+```
+
 ### Scripts
 
 Utility scripts live under the `scripts/` directory. `setup_codex.sh` clones the


### PR DESCRIPTION
## Summary
- document how to run the generative AI reporter agent in README
- track new task `document reporter agent invocation`

## Testing
- `bun test --coverage`
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683fb956df54832fb158d199cab710c7