### PR TITLE
Add usage example and tests for GenerativeAIReporterAgent

### DIFF
--- a/.vibe/projects.md
+++ b/.vibe/projects.md
@@ -5,4 +5,5 @@ This file lists the major Nx projects in the repository. Update it whenever a pr
 - **client** – React front-end for the Bot-or-Not game (`apps/client`)
 - **server** – Node server for the game (`apps/server`)
 - **task-cli** – Library providing a small RSS-based news gatherer (`libs/task-cli`)
+- **generative-ai-reporter-agent** – Library ranking repositories and generating reports (`agents/generative-ai-reporter-agent`)
 

--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -11,4 +11,5 @@ corresponding folder under `.vibe/tasks` with additional documentation.
 - [x] Add TypeScript type packages
 - [x] Update README with agentic tools description
 - [x] Create example agent
+- [x] Add GenerativeAIReporterAgent
 

--- a/.vibe/tasks/add-generative-ai-reporter-agent/task-add-generative-ai-reporter-agent.md
+++ b/.vibe/tasks/add-generative-ai-reporter-agent/task-add-generative-ai-reporter-agent.md
@@ -1,0 +1,3 @@
+# Add GenerativeAIReporterAgent
+
+Create a new Nx library `generative-ai-reporter-agent` under `agents/`. It should rank repositories by star count and generate a textual report. Add unit tests covering the ranking and output functions and update documentation to mention the new agent.

--- a/README.md
+++ b/README.md
@@ -26,12 +26,21 @@ bun run index.ts
 This project was created using `bun init` in bun v1.2.10.
 `mcp.json` in the repo root holds MCP-related configuration, while the `.vibe`
 directory is reserved for project metadata used by agents. An example agent lives
-in `agents/example` and simply prints a message when run.
+in `agents/example` and simply prints a message when run. The
+`GenerativeAIReporterAgent` under `agents/generative-ai-reporter-agent` ranks
+repositories and outputs a small report.
 
-You can run it with:
+You can invoke the reporter like this:
 
-```bash
-bun run agents/example/index.ts
+```ts
+import {run} from './agents/generative-ai-reporter-agent';
+
+console.log(
+  run([
+    {name: 'repo1', stars: 10},
+    {name: 'repo2', stars: 5}
+  ])
+);
 ```
 
 All task documentation lives under `.vibe/tasks`.

--- a/agents/generative-ai-reporter-agent/project.json
+++ b/agents/generative-ai-reporter-agent/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "generative-ai-reporter-agent",
+  "root": "agents/generative-ai-reporter-agent",
+  "sourceRoot": "agents/generative-ai-reporter-agent/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "options": {
+        "outputPath": "dist/agents/generative-ai-reporter-agent",
+        "main": "agents/generative-ai-reporter-agent/src/index.ts",
+        "tsConfig": "agents/generative-ai-reporter-agent/tsconfig.lib.json"
+      }
+    }
+  }
+}

--- a/agents/generative-ai-reporter-agent/src/__tests__/index.test.ts
+++ b/agents/generative-ai-reporter-agent/src/__tests__/index.test.ts
@@ -1,0 +1,34 @@
+import {rankRepos, generateReport, run} from '../index';
+import type {RepoInfo} from '../index';
+import {expect, test} from 'bun:test';
+
+test('rankRepos sorts by stars descending', () => {
+  const repos: RepoInfo[] = [
+    {name: 'b', stars: 2},
+    {name: 'a', stars: 5},
+    {name: 'c', stars: 3}
+  ];
+  const ranked = rankRepos(repos);
+  expect(ranked[0]?.name).toBe('a');
+  expect(ranked[1]?.name).toBe('c');
+  expect(ranked[2]?.name).toBe('b');
+});
+
+test('generateReport outputs ranked list', () => {
+  const repos: RepoInfo[] = [
+    {name: 'repo1', stars: 10},
+    {name: 'repo2', stars: 5}
+  ];
+  const report = generateReport(repos);
+  expect(report.split('\n')[0]).toContain('repo1');
+  expect(report.split('\n')[1]).toContain('repo2');
+});
+
+test('run wraps generateReport', () => {
+  const repos: RepoInfo[] = [
+    {name: 'r1', stars: 7},
+    {name: 'r2', stars: 3}
+  ];
+  const result = run(repos);
+  expect(result).toBe(generateReport(repos));
+});

--- a/agents/generative-ai-reporter-agent/src/index.ts
+++ b/agents/generative-ai-reporter-agent/src/index.ts
@@ -1,0 +1,19 @@
+export interface RepoInfo {
+  name: string;
+  stars: number;
+}
+
+export function rankRepos(repos: RepoInfo[]): RepoInfo[] {
+  return [...repos].sort((a, b) => b.stars - a.stars);
+}
+
+export function generateReport(repos: RepoInfo[]): string {
+  const ranked = rankRepos(repos);
+  return ranked
+    .map((repo, i) => `${i + 1}. ${repo.name} (${repo.stars}\u2B50)`)
+    .join('\n');
+}
+
+export function run(repos: RepoInfo[]): string {
+  return generateReport(repos);
+}

--- a/agents/generative-ai-reporter-agent/tsconfig.lib.json
+++ b/agents/generative-ai-reporter-agent/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "../../dist/agents/generative-ai-reporter-agent"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+}

--- a/mcp.json
+++ b/mcp.json
@@ -17,6 +17,11 @@
       "name": "task-cli",
       "entry": "libs/task-cli",
       "description": "RSS news gatherer library"
+    },
+    {
+      "name": "generative-ai-reporter-agent",
+      "entry": "agents/generative-ai-reporter-agent",
+      "description": "Ranks repositories and generates a report"
     }
   ],
   "settings": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "workspaces": [
     "apps/*",
-    "libs/*"
+    "libs/*",
+    "agents/*"
   ],
   "scripts": {
     "nx": "nx",


### PR DESCRIPTION
## Summary
- document how to invoke the GenerativeAIReporterAgent in the README
- exclude `.test.ts` files from the agent library build
- include the agents directory in workspace configuration
- add a unit test covering the `run()` helper

## Testing
- `bun test --coverage`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6835171cd578832fa23591085499b49f