### PR TITLE
Document absence of agentic scripts

### DIFF
--- a/.vibe/tasks.md
+++ b/.vibe/tasks.md
@@ -12,4 +12,5 @@ corresponding folder under `.vibe/tasks` with additional documentation.
 - [x] Update README with agentic tools description
 - [x] Add fetch error handling
 - [x] [Create queue activity](tasks/create-queue-activity)
+- [x] [Confirm agentic scripts](tasks/confirm-agentic-scripts)
 

--- a/.vibe/tasks/confirm-agentic-scripts/task-confirm-agentic-scripts.md
+++ b/.vibe/tasks/confirm-agentic-scripts/task-confirm-agentic-scripts.md
@@ -1,0 +1,16 @@
+# Confirm agentic scripts
+
+Investigate Nx project names for the planned chat API and web app and update or remove the `agentic:dev` and `agentic:test` scripts accordingly.
+
+## Findings
+
+- The workspace currently defines the following Nx projects: `client`, `server`, and `task-cli`.
+- There are no projects named `chat-api` or `web-app` yet.
+- `package.json` contains no `agentic:dev` or `agentic:test` scripts.
+- No `scripts/setup-local-dev.sh` file exists.
+
+## Outcome
+
+No code changes were needed. The scripts referenced in the request do not exist, so nothing required updating or removing.
+
+See `user-instructions.md` in this folder for guidance on rebasing the pull request branch onto `main`.

--- a/.vibe/tasks/confirm-agentic-scripts/user-instructions.md
+++ b/.vibe/tasks/confirm-agentic-scripts/user-instructions.md
@@ -1,0 +1,12 @@
+# Instructions for repository owner
+
+The user has requested that the pull request branch be rebased onto `main` and that any merge conflicts are resolved. The container currently has no remote repositories configured, so a rebase cannot be performed automatically.
+
+Please configure a remote for this repository and run:
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+Resolve any merge conflicts that arise and push the updated branch before reviewing this pull request.


### PR DESCRIPTION
## Summary
- add task documentation confirming that agentic scripts do not exist
- record the task in `.vibe/tasks.md`
- document how to rebase the PR onto `main`

## Testing
- `bun run tsc --noEmit`
- `bun test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_683f8bf3586c832f9c08a9b734258731